### PR TITLE
Fixed missing static function to destroy current instance

### DIFF
--- a/src/Base.php
+++ b/src/Base.php
@@ -34,7 +34,7 @@ class Base
     /**
      * @return void
      */
-    public function destroy()
+    public static function destroy()
     {
         static::$instance = null;
     }


### PR DESCRIPTION
Dear ajant,
I wanted to destroy created instance but I could not do that using current non static method destroy. This method have to be static to be able to set current instance to null.

Thanks
Milan